### PR TITLE
Fix running BMD's precommit hooks on Windows

### DIFF
--- a/hooks/check_accidental_assignment.py
+++ b/hooks/check_accidental_assignment.py
@@ -197,7 +197,7 @@ def check_accidental_assignment(
         ignore_keywords: list[str] | None = None,
         quiet: bool = False,
 ) -> int:
-    with open(filename) as f:
+    with open(filename, encoding='utf-8') as f:
         contents = f.read()
 
     lines = contents.splitlines()

--- a/hooks/check_hex_case.py
+++ b/hooks/check_hex_case.py
@@ -24,7 +24,7 @@ def match_fix_hex(match_object, upper_preffix: bool = False, upper_digits: bool 
 
 
 def check_hex_case(filename: str, edit_in_place: bool = False, upper_preffix: bool = False, upper_digits: bool = True) -> int:
-    with open(filename) as f:
+    with open(filename, encoding='utf-8') as f:
         contents = f.read()
 
     match_callback = partial(

--- a/hooks/check_include_guards.py
+++ b/hooks/check_include_guards.py
@@ -20,7 +20,7 @@ def check_include_guard(filename: str, relative_to: str = None, edit_in_place: b
     need_fix = False
 
     # Read as binary so we can read byte-by-byte
-    with open(filename, 'rb+') as file_obj:
+    with open(filename, 'rb+', encoding='utf-8') as file_obj:
 
         i1, line1 = None, None
         for i2, line2 in enumerate(file_obj, start=1):


### PR DESCRIPTION
Hi @perigoso,

I've recently enabled the precommit hooks for BMD on Windows and ran into the following error:

```
Traceback (most recent call last):
  File "C:\Program Files\Python310\lib\runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "C:\Program Files\Python310\lib\runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "C:\Users\Amalia\.cache\pre-commit\repo9msy0j5p\py_env-python3.10\Scripts\check-accidental-assignment.EXE\__main__.py", line 7, in <module>
  File "C:\Users\Amalia\.cache\pre-commit\repo9msy0j5p\py_env-python3.10\lib\site-packages\hooks\check_accidental_assignment.py", line 261, in main
    retv |= check_accidental_assignment(
  File "C:\Users\Amalia\.cache\pre-commit\repo9msy0j5p\py_env-python3.10\lib\site-packages\hooks\check_accidental_assignment.py", line 201, in check_accidental_assignment
    contents = f.read()
  File "C:\Program Files\Python310\lib\encodings\cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
UnicodeDecodeError: 'charmap' codec can't decode byte 0x90 in position 2269: character maps to <undefined>
```

As shown in the `f.read()` line, this means that it'll apply [the system default encoding](https://docs.python.org/3/library/functions.html#open) which in Windows should be ISO-8859-1 and not UTF-8 as in Linux.

This PR fixes the issue on the three hooks provided.